### PR TITLE
Release 0.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-motoko",
-    "version": "0.22.2",
+    "version": "0.23.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-motoko",
-            "version": "0.22.2",
+            "version": "0.23.0",
             "hasInstallScript": true,
             "dependencies": {
                 "@iarna/toml": "^2.2.5",
@@ -19,7 +19,7 @@
                 "ic-mops": "^2.0.1",
                 "ic0": "0.3.1",
                 "mnemonist": "0.39.5",
-                "motoko": "^4.0.1",
+                "motoko": "^4.2.0",
                 "neverthrow": "^8.2.0",
                 "prettier": "2.8.0",
                 "prettier-plugin-motoko": "0.12.0",
@@ -13186,15 +13186,15 @@
             }
         },
         "node_modules/motoko": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/motoko/-/motoko-4.0.1.tgz",
-            "integrity": "sha512-jAm59/xmZ3hRJNEIOmUDf2FvLJjG0NlzNkQPMcdSm3zEpVVmhv0kfE8zhOR/1WuX7Q+ddzn5a13AlOPw60bGsw==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/motoko/-/motoko-4.2.0.tgz",
+            "integrity": "sha512-r3SctS3x8IcLrO+EI56C4uO4xky4h/mynEk/xU5StNkVM9TzKYdO7+rYopRD6NdDCdx68cGsL8XIi+mpJrRY5g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "cross-fetch": "3.1.5",
-                "debug": "4.3.4",
+                "debug": "^4.4.3",
                 "parse-github-url": "1.0.3",
-                "sanitize-filename": "1.6.3"
+                "sanitize-filename": "^1.6.4"
             }
         },
         "node_modules/motoko/node_modules/cross-fetch": {
@@ -13205,29 +13205,6 @@
             "dependencies": {
                 "node-fetch": "2.6.7"
             }
-        },
-        "node_modules/motoko/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/motoko/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "license": "MIT"
         },
         "node_modules/motoko/node_modules/node-fetch": {
             "version": "2.6.7",
@@ -14907,9 +14884,9 @@
             "license": "MIT"
         },
         "node_modules/sanitize-filename": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-            "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+            "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
             "license": "WTFPL OR ISC",
             "dependencies": {
                 "truncate-utf8-bytes": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.22.2",
+    "version": "0.23.0",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/caffeinelabs/vscode-motoko",
     "engines": {
@@ -193,7 +193,7 @@
         "ic-mops": "^2.0.1",
         "ic0": "0.3.1",
         "mnemonist": "0.39.5",
-        "motoko": "^4.0.1",
+        "motoko": "^4.2.0",
         "neverthrow": "^8.2.0",
         "prettier": "2.8.0",
         "prettier-plugin-motoko": "0.12.0",


### PR DESCRIPTION
## Summary

- Bump bundled `motoko` npm package from `4.0.1` to `4.2.0` (moc 1.4.1)
- Bump extension version to `0.23.0`

### Changes included in this release (since v0.22.2)

- **feat**: Read moc flags from `mops.toml` `[moc].args` per project (#448)
- **chore**: Enforce 7-day minimum release age for supply-chain hardening (#449)
- **dep**: Bump bundled Motoko compiler (moc 1.3.0 → 1.4.1)

## Test plan

- [ ] CI passes
- [ ] After merge, draft a GitHub release with tag `v0.23.0` and generate release notes

Made with [Cursor](https://cursor.com)