### PR TITLE
fix: bypass min-release-age for motoko update workflow

### DIFF
--- a/.github/workflows/update-motoko.yml
+++ b/.github/workflows/update-motoko.yml
@@ -56,8 +56,7 @@ jobs:
             exit 0
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"
-          npm pkg set "dependencies.motoko=^${target}"
-          npm install
+          npm install "motoko@^${target}" --min-release-age=0  # bypass .npmrc quarantine for fresh releases
           npm version "$VERSION_BUMP" --no-git-tag-version
 
       - name: Cache mops packages


### PR DESCRIPTION
## Problem

The `update-motoko` workflow fires via `repository_dispatch` within seconds of a new `motoko` version being published to npm. However, the repo-wide `.npmrc` sets `min-release-age=7`, which rejects any package published less than 7 days ago.

This means `npm install` always fails when this workflow runs — the version it's trying to install is seconds old, but npm requires it to be at least 7 days old.

**CI run**: https://github.com/caffeinelabs/vscode-motoko/actions/runs/24339925268/job/71066040003

```
npm error notarget No matching version found for motoko@^4.4.0
  with a date before 4/6/2026, 11:03:18 AM.
```

## Root cause

`min-release-age=7` in `.npmrc` (added in #449) applies globally to all `npm install` invocations, including the automated motoko update workflow whose entire purpose is to consume a freshly-published version.

## Fix

Override with `--min-release-age=0` on the single `npm install` call in the update-motoko workflow. The `.npmrc` setting continues to protect all other installs (CI tests, local dev, etc.).

This is safe because `motoko` is a first-party dependency dispatched by our own release pipeline — the supply-chain risk that `min-release-age` guards against doesn't apply here.

Made with [Cursor](https://cursor.com)