### PR TITLE
ci: bump actions to v5 (Node.js 24 runtime)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,16 +20,16 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
     - run: npm run compile
     - name: Cache mops packages
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         key: mops-packages-${{ hashFiles('test/**/mops.toml') }}
         restore-keys: |


### PR DESCRIPTION
## Summary

GitHub Actions runners deprecate Node.js 20 (default switch **June 2, 2026**; removal **September 16, 2026**). The `Tests` workflow currently triggers a deprecation warning on every run because all three actions are pinned to Node-20-era SHAs. Example annotation on a recent run:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/cache@0057852…`, `actions/checkout@f43a0e5…`, `actions/setup-node@3235b87…`. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

This PR bumps each to a release that ships with Node.js 24:

| action | from | to |
|--|--|--|
| `actions/checkout` | v3.6.0 (`f43a0e5`) | **v5.0.1** (`93cb6ef`) |
| `actions/setup-node` | v3.9.1 (`3235b87`) | **v5.0.0** (`a0853c2`) |
| `actions/cache` | v4.3.0 (`0057852`) | **v5.0.5** (`27d5ce7`) |

Pins remain as full SHAs (with the human-readable version in a trailing comment) per the existing file style.

## Test plan

- [ ] CI passes (Tests workflow)
- [ ] Deprecation warning on the run is gone
- [ ] mops cache still hits across runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)