### PR TITLE
Add motoko.lite setting to disable the language server

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,13 @@ Below are the default key bindings for commonly used features supported in the e
 - `motoko.canister`: The default canister name to use in multi-canister projects
 - `motoko.formatter`: The formatter used by the language server
 - `motoko.mocJsPath`: Path to moc.js file for using a custom Motoko version
-- `motoko.lite`: Light mode. Disables the language server (type checking, completions, hover, go to definition, references/rename, code actions, signature help, workspace symbols, **format on save / format document**, and the "Import Mops Package" command) to reduce memory and CPU usage. Syntax highlighting, snippets, and `dfx.json` schema validation keep working — those come from the TextMate grammar and schema validator, not the language server. Set this (e.g. `"motoko.lite": true`) in your **workspace** `settings.json` when you want a minimal, lightweight Motoko editing experience. Note: because this is a workspace-scoped (`scope: "resource"`) setting, setting it in your *user* or *remote* `settings.json` will have no effect. It takes effect after reloading the window.
+- `motoko.lite`: Light mode. Disables the language server (type checking, completions, hover, go to definition, references/rename, code actions, signature help, workspace symbols, **format on save / format document**, and the "Import Mops Package" command) to reduce memory and CPU usage. Syntax highlighting, snippets, and `dfx.json` schema validation keep working — those come from the TextMate grammar, the snippets contribution, and the built-in JSON validator, not from the language server. Set this (e.g. `"motoko.lite": true`) when you want a minimal, lightweight Motoko editing experience. It is `resource`-scoped, so you can set it in your user/remote settings to enable lite mode everywhere, or in a workspace/folder's `.vscode/settings.json` to enable it only for that project. It takes effect after reloading the window.
 
 ## Advanced Configuration
 
 If you want VS Code to automatically format Motoko files on save, consider adding the following to your `settings.json` configuration:
+
+> **Note:** these formatter settings only take effect when the language server is running. With `motoko.lite` enabled (see the `motoko.lite` setting above), format-on-save is disabled, since formatting is provided by the language server.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Below are the default key bindings for commonly used features supported in the e
 - `motoko.canister`: The default canister name to use in multi-canister projects
 - `motoko.formatter`: The formatter used by the language server
 - `motoko.mocJsPath`: Path to moc.js file for using a custom Motoko version
+- `motoko.lite`: Light mode. Disables the language server (type checking, completions, hover, go to definition, references/rename, code actions, signature help, workspace symbols, and the "Import Mops Package" command) to reduce memory and CPU usage. Syntax highlighting, formatting, snippets, and `dfx.json` schema validation keep working, since none of those come from the language server. Set this (e.g. `"motoko.lite": true`) in your `settings.json` when you want a minimal, lightweight Motoko editing experience — it takes effect after reloading the window.
 
 ## Advanced Configuration
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Below are the default key bindings for commonly used features supported in the e
 - `motoko.canister`: The default canister name to use in multi-canister projects
 - `motoko.formatter`: The formatter used by the language server
 - `motoko.mocJsPath`: Path to moc.js file for using a custom Motoko version
-- `motoko.lite`: Light mode. Disables the language server (type checking, completions, hover, go to definition, references/rename, code actions, signature help, workspace symbols, and the "Import Mops Package" command) to reduce memory and CPU usage. Syntax highlighting, formatting, snippets, and `dfx.json` schema validation keep working, since none of those come from the language server. Set this (e.g. `"motoko.lite": true`) in your `settings.json` when you want a minimal, lightweight Motoko editing experience — it takes effect after reloading the window.
+- `motoko.lite`: Light mode. Disables the language server (type checking, completions, hover, go to definition, references/rename, code actions, signature help, workspace symbols, **format on save / format document**, and the "Import Mops Package" command) to reduce memory and CPU usage. Syntax highlighting, snippets, and `dfx.json` schema validation keep working — those come from the TextMate grammar and schema validator, not the language server. Set this (e.g. `"motoko.lite": true`) in your **workspace** `settings.json` when you want a minimal, lightweight Motoko editing experience. Note: because this is a workspace-scoped (`scope: "resource"`) setting, setting it in your *user* or *remote* `settings.json` will have no effect. It takes effect after reloading the window.
 
 ## Advanced Configuration
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.23.6",
+    "version": "0.24.0",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/caffeinelabs/vscode-motoko",
     "engines": {
@@ -125,6 +125,12 @@
                     "type": "string",
                     "default": "",
                     "description": "Path to moc.js file for using a custom Motoko version (absolute, or relative to workspace root). Only load moc.js files from trusted sources."
+                },
+                "motoko.lite": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Light mode: disables the language server (type checking, completions, hover, go to definition, references/rename, code actions, signature help, workspace symbols, and the 'Import Mops Package' command) to reduce memory and CPU usage. Keeps syntax highlighting, formatting, and snippets. Takes effect after reloading the window."
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
                     "scope": "resource",
                     "type": "boolean",
                     "default": false,
-                    "description": "Light mode: disables the language server (type checking, completions, hover, go to definition, references/rename, code actions, signature help, workspace symbols, and the 'Import Mops Package' command) to reduce memory and CPU usage. Keeps syntax highlighting, formatting, and snippets. Takes effect after reloading the window."
+                    "description": "Light mode: disables the language server (type checking, completions, hover, go to definition, references/rename, code actions, signature help, workspace symbols, format on save / format document, and the 'Import Mops Package' command) to reduce memory and CPU usage. Keeps syntax highlighting, snippets, and dfx.json schema validation. See the README 'motoko.lite' setting for details. Takes effect after reloading the window."
                 }
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,7 +38,8 @@ let client: LanguageClient;
 export function activate(context: ExtensionContext) {
     // Lite mode: skip the language server entirely (and everything that depends
     // on it) to reduce memory and CPU usage. Keeps syntax highlighting,
-    // formatting, and snippets, since those don't come from the server.
+    // snippets, and dfx.json schema validation, since those don't come from
+    // the server. Formatting is also server-provided, so it's disabled too.
     const lite = workspace.getConfiguration('motoko').get<boolean>('lite');
     if (lite) {
         // Log channel is only created in lite mode, so regular mode has zero
@@ -48,7 +49,7 @@ export function activate(context: ExtensionContext) {
             log: true,
         });
         liteLogger.appendLine(
-            `Motoko lite mode is ON (motoko.lite): the language server is disabled, so type checking, completions, hover, go to definition, references/rename, code actions, signature help, workspace symbols, and the "Import Mops Package" command are unavailable. Syntax highlighting, formatting, snippets, and dfx.json schema validation keep working. Set "motoko.lite" to false and reload the window to re-enable the language server.`,
+            `Motoko lite mode is ON (motoko.lite): the language server is disabled, so type checking, completions, hover, go to definition, references/rename, code actions, signature help, workspace symbols, formatting, and the "Import Mops Package" command are unavailable. Syntax highlighting, snippets, and dfx.json schema validation keep working. Set "motoko.lite" to false and reload the window to re-enable the language server.`,
         );
         context.subscriptions.push(
             liteLogger,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,19 @@ import { ignoreGlobPatterns, watchGlob } from './common/watchConfig';
 let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
+    // Lite mode: skip the language server entirely (and everything that depends
+    // on it) to reduce memory and CPU usage. Keeps syntax highlighting,
+    // formatting, and snippets, since those don't come from the server.
+    if (workspace.getConfiguration('motoko').get<boolean>('lite')) {
+        context.subscriptions.push(
+            commands.registerCommand('motoko.startService', () =>
+                window.showInformationMessage(
+                    'Motoko lite mode is on: the language server is disabled. Turn off "motoko.lite" to enable type checking, completions, hover, and navigation.',
+                ),
+            ),
+        );
+        return;
+    }
     context.subscriptions.push(
         commands.registerCommand('motoko.startService', () =>
             startServer(context),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,8 +39,19 @@ export function activate(context: ExtensionContext) {
     // Lite mode: skip the language server entirely (and everything that depends
     // on it) to reduce memory and CPU usage. Keeps syntax highlighting,
     // formatting, and snippets, since those don't come from the server.
-    if (workspace.getConfiguration('motoko').get<boolean>('lite')) {
+    const lite = workspace.getConfiguration('motoko').get<boolean>('lite');
+    if (lite) {
+        // Log channel is only created in lite mode, so regular mode has zero
+        // footprint. Since there is no language server in lite mode, this
+        // single entry is the only place users can see that the setting is on.
+        const liteLogger = window.createOutputChannel('Motoko', {
+            log: true,
+        });
+        liteLogger.appendLine(
+            `Motoko lite mode is ON (motoko.lite): the language server is disabled, so type checking, completions, hover, go to definition, references/rename, code actions, signature help, workspace symbols, and the "Import Mops Package" command are unavailable. Syntax highlighting, formatting, snippets, and dfx.json schema validation keep working. Set "motoko.lite" to false and reload the window to re-enable the language server.`,
+        );
         context.subscriptions.push(
+            liteLogger,
             commands.registerCommand('motoko.startService', () =>
                 window.showInformationMessage(
                     'Motoko lite mode is on: the language server is disabled. Turn off "motoko.lite" to enable type checking, completions, hover, and navigation.',


### PR DESCRIPTION
## Summary

Fixes the "heavy compute + memory" experience of the Motoko extension by letting users opt out of the language server entirely via a new per-workspace `motoko.lite` setting (default `false`).

The extension currently boots a full language server that embeds the bundled `moc.js` WASM compiler (~8MB once bundled) and type-checks every open/entry-point `.mo` on each edit. We don't have time to slim that down, so this PR exposes the cheap alternative: **skip the server at activation** and keep only the features that don't depend on it.

## Key insight

Syntax highlighting never came from the server — it's the TextMate grammar registered purely via `contributes.grammars`. So disabling the server keeps highlighting, snippets, and `dfx.json` schema validation (the built-in JSON validator) while dropping everything that needs the compiler/typed AST. Note that formatting is not kept: it is also server-provided (`connection.onDocumentFormatting`), so in lite mode format-on-save / Format Document is disabled along with the rest.

## What changes in lite mode

**Keeps working (client-side, ~zero cost):**
- Syntax highlighting (TextMate grammar)
- Snippets
- `dfx.json` schema validation (built-in JSON validator)

**Disabled (all server-dependent):**
- Diagnostics / type checking
- Completions (incl. contextual-dot)
- Hover with types & docs
- Go to definition, workspace symbols
- Signature help
- References / rename / prepare-rename
- Code actions (organize imports, import quick-fixes)
- Formatting (format-on-save / Format Document)
- "Import Mops Package" command

**Memory/compute win:** the language server never starts, so the `motoko` npm package + `moc.js` WASM compiler never load into the extension host. No workspace scan for Mops/Vessel/dfx, no check queue, no typed-AST reparse loop.

## Implementation

- `package.json`: new `motoko.lite` setting (boolean, scope `resource`, default `false`); version bumped `0.23.6 → 0.24.0`
- `src/extension.ts`: early-return in `activate()` when lite is on; `Motoko: Restart language server` becomes a no-op with an explanatory message instead of silently failing
- `src/extension.ts`: in lite mode, a single line is written to a `Motoko` log channel (Output → Extension Logs → Motoko, also persisted to disk) so users who set and forgot `motoko.lite` can find why features are missing. The channel is only created in the lite branch — zero footprint in normal mode.
- `README.md`: documents lite mode, including the workspace/user scope semantics and that formatter settings only apply while the server runs

Takes effect on window reload (documented). No server-side changes.

## Verification

- `npm run compile` ✅
- `npm run lint` ✅ (zero warnings)
- `npm test` ✅ 24 suites / 276 tests all pass
- Reviewed via a fix-review loop; no critical or warning findings remain
- Manual runtime check with the setting enabled is still needed from a dev window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)