### PR TITLE
ci: bump actions to latest, fix Node 20 deprecation, bump @vscode/vsce to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Install
       run: npm ci
     - name: Package

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,16 +20,16 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
     - run: npm run compile
     - name: Cache mops packages
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         key: mops-packages-${{ hashFiles('test/**/mops.toml') }}
         restore-keys: |

--- a/.github/workflows/update-motoko.yml
+++ b/.github/workflows/update-motoko.yml
@@ -22,9 +22,9 @@ jobs:
   update-motoko:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -61,7 +61,7 @@ jobs:
 
       - name: Cache mops packages
         if: steps.meta.outputs.skip != 'true'
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           key: mops-packages-${{ hashFiles('test/**/mops.toml') }}
           restore-keys: |
@@ -78,14 +78,14 @@ jobs:
       - name: Generate GitHub App token
         if: steps.meta.outputs.skip != 'true'
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.GENERIC_CI_RW_APP_ID }}
           private-key: ${{ secrets.GENERIC_CI_RW_APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         if: steps.meta.outputs.skip != 'true'
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           base: master

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
                 "@types/prettier": "^2.7.0",
                 "@types/semver": "^7.7.1",
                 "@types/vscode": "^1.53.0",
-                "@vscode/vsce": "^2.15.0",
+                "@vscode/vsce": "^3.9.2",
                 "esbuild": "^0.28.1",
                 "eslint": "^9.39.2",
                 "eslint-plugin-jest": "^28.14.0",
@@ -114,6 +114,23 @@
             "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
             "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
             "license": "MIT"
+        },
+        "node_modules/@azu/format-text": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@azu/format-text/-/format-text-1.0.2.tgz",
+            "integrity": "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@azu/style-format": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@azu/style-format/-/style-format-1.0.1.tgz",
+            "integrity": "sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==",
+            "dev": true,
+            "license": "WTFPL",
+            "dependencies": {
+                "@azu/format-text": "^1.0.1"
+            }
         },
         "node_modules/@azure/abort-controller": {
             "version": "2.1.2",
@@ -3570,6 +3587,233 @@
             "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
             "license": "MIT"
         },
+        "node_modules/@secretlint/config-creator": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-10.2.2.tgz",
+            "integrity": "sha512-BynOBe7Hn3LJjb3CqCHZjeNB09s/vgf0baBaHVw67w7gHF0d25c3ZsZ5+vv8TgwSchRdUCRrbbcq5i2B1fJ2QQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@secretlint/types": "^10.2.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@secretlint/config-loader": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/config-loader/-/config-loader-10.2.2.tgz",
+            "integrity": "sha512-ndjjQNgLg4DIcMJp4iaRD6xb9ijWQZVbd9694Ol2IszBIbGPPkwZHzJYKICbTBmh6AH/pLr0CiCaWdGJU7RbpQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@secretlint/profiler": "^10.2.2",
+                "@secretlint/resolver": "^10.2.2",
+                "@secretlint/types": "^10.2.2",
+                "ajv": "^8.17.1",
+                "debug": "^4.4.1",
+                "rc-config-loader": "^4.1.3"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@secretlint/config-loader/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@secretlint/config-loader/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@secretlint/core": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/core/-/core-10.2.2.tgz",
+            "integrity": "sha512-6rdwBwLP9+TO3rRjMVW1tX+lQeo5gBbxl1I5F8nh8bgGtKwdlCMhMKsBWzWg1ostxx/tIG7OjZI0/BxsP8bUgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@secretlint/profiler": "^10.2.2",
+                "@secretlint/types": "^10.2.2",
+                "debug": "^4.4.1",
+                "structured-source": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@secretlint/formatter": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/formatter/-/formatter-10.2.2.tgz",
+            "integrity": "sha512-10f/eKV+8YdGKNQmoDUD1QnYL7TzhI2kzyx95vsJKbEa8akzLAR5ZrWIZ3LbcMmBLzxlSQMMccRmi05yDQ5YDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@secretlint/resolver": "^10.2.2",
+                "@secretlint/types": "^10.2.2",
+                "@textlint/linter-formatter": "^15.2.0",
+                "@textlint/module-interop": "^15.2.0",
+                "@textlint/types": "^15.2.0",
+                "chalk": "^5.4.1",
+                "debug": "^4.4.1",
+                "pluralize": "^8.0.0",
+                "strip-ansi": "^7.1.0",
+                "table": "^6.9.0",
+                "terminal-link": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@secretlint/formatter/node_modules/ansi-regex": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+            "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/@secretlint/formatter/node_modules/chalk": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@secretlint/formatter/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@secretlint/node": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/node/-/node-10.2.2.tgz",
+            "integrity": "sha512-eZGJQgcg/3WRBwX1bRnss7RmHHK/YlP/l7zOQsrjexYt6l+JJa5YhUmHbuGXS94yW0++3YkEJp0kQGYhiw1DMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@secretlint/config-loader": "^10.2.2",
+                "@secretlint/core": "^10.2.2",
+                "@secretlint/formatter": "^10.2.2",
+                "@secretlint/profiler": "^10.2.2",
+                "@secretlint/source-creator": "^10.2.2",
+                "@secretlint/types": "^10.2.2",
+                "debug": "^4.4.1",
+                "p-map": "^7.0.3"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@secretlint/profiler": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-10.2.2.tgz",
+            "integrity": "sha512-qm9rWfkh/o8OvzMIfY8a5bCmgIniSpltbVlUVl983zDG1bUuQNd1/5lUEeWx5o/WJ99bXxS7yNI4/KIXfHexig==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@secretlint/resolver": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/resolver/-/resolver-10.2.2.tgz",
+            "integrity": "sha512-3md0cp12e+Ae5V+crPQYGd6aaO7ahw95s28OlULGyclyyUtf861UoRGS2prnUrKh7MZb23kdDOyGCYb9br5e4w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@secretlint/secretlint-formatter-sarif": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/secretlint-formatter-sarif/-/secretlint-formatter-sarif-10.2.2.tgz",
+            "integrity": "sha512-ojiF9TGRKJJw308DnYBucHxkpNovDNu1XvPh7IfUp0A12gzTtxuWDqdpuVezL7/IP8Ua7mp5/VkDMN9OLp1doQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "node-sarif-builder": "^3.2.0"
+            }
+        },
+        "node_modules/@secretlint/secretlint-rule-no-dotenv": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-no-dotenv/-/secretlint-rule-no-dotenv-10.2.2.tgz",
+            "integrity": "sha512-KJRbIShA9DVc5Va3yArtJ6QDzGjg3PRa1uYp9As4RsyKtKSSZjI64jVca57FZ8gbuk4em0/0Jq+uy6485wxIdg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@secretlint/types": "^10.2.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@secretlint/secretlint-rule-preset-recommend": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-preset-recommend/-/secretlint-rule-preset-recommend-10.2.2.tgz",
+            "integrity": "sha512-K3jPqjva8bQndDKJqctnGfwuAxU2n9XNCPtbXVI5JvC7FnQiNg/yWlQPbMUlBXtBoBGFYp08A94m6fvtc9v+zA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@secretlint/source-creator": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/source-creator/-/source-creator-10.2.2.tgz",
+            "integrity": "sha512-h6I87xJfwfUTgQ7irWq7UTdq/Bm1RuQ/fYhA3dtTIAop5BwSFmZyrchph4WcoEvbN460BWKmk4RYSvPElIIvxw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@secretlint/types": "^10.2.2",
+                "istextorbinary": "^9.5.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@secretlint/types": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/types/-/types-10.2.2.tgz",
+            "integrity": "sha512-Nqc90v4lWCXyakD6xNyNACBJNJ0tNCwj2WNk/7ivyacYHxiITVgmLUFXTBOeCdy79iz6HtN9Y31uw/jbLrdOAg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/@sinclair/typebox": {
             "version": "0.27.8",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -3631,6 +3875,101 @@
             },
             "engines": {
                 "node": ">=14.16"
+            }
+        },
+        "node_modules/@textlint/ast-node-types": {
+            "version": "15.8.0",
+            "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.8.0.tgz",
+            "integrity": "sha512-5CiH9COYmovWmExQgs7763DzX6Gy9zjkjJ7JxCC95wyTcjwQn/8poNF6fv3qzRlmx8CRRde8DHr9FcgAAiPzgw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@textlint/linter-formatter": {
+            "version": "15.8.0",
+            "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.8.0.tgz",
+            "integrity": "sha512-+oU3A235NATv6Lzi4xa4kJ65PuNJlIxesaO4AvDhDWA9FWm7y4XKWaoQCW1esgaQQ6dwnUiFKArQ8TcJ86mC4w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@azu/format-text": "^1.0.2",
+                "@azu/style-format": "^1.0.1",
+                "@textlint/module-interop": "15.8.0",
+                "@textlint/resolver": "15.8.0",
+                "@textlint/types": "15.8.0",
+                "debug": "^4.4.3",
+                "js-yaml": "^4.3.0",
+                "lodash": "^4.18.1",
+                "pluralize": "^2.0.0",
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1",
+                "table": "^6.9.0",
+                "text-table": "^0.2.0"
+            },
+            "engines": {
+                "node": ">=20.18.0"
+            }
+        },
+        "node_modules/@textlint/linter-formatter/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@textlint/linter-formatter/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@textlint/linter-formatter/node_modules/pluralize": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-2.0.0.tgz",
+            "integrity": "sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@textlint/linter-formatter/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@textlint/module-interop": {
+            "version": "15.8.0",
+            "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.8.0.tgz",
+            "integrity": "sha512-rt+OR1WYGoLOY8HkA/aBPrqufF6yUUEsKEAh7XohTsT3lp9IyZFT6zOIbjul9P4FAzsmSPkcrYjVx3Bz/IUfkg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@textlint/resolver": {
+            "version": "15.8.0",
+            "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.8.0.tgz",
+            "integrity": "sha512-E88tzfX3K8Jykk+38aJ9cy8RquD8ABVOPTO2rFEESq0wcg8x6/ypdAS8ZgR7OKiGqlRF0hkO/m5PbQwVfKM3VA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@textlint/types": {
+            "version": "15.8.0",
+            "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.8.0.tgz",
+            "integrity": "sha512-Anhc6y5736YIsvqae0U6k0YmB2M/QVHkEeOv2aydAn/WIkdI69dCOiDbe3/+RagS3qstFTSFWJzNRA2lUjv19w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@textlint/ast-node-types": "15.8.0"
             }
         },
         "node_modules/@tybys/wasm-util": {
@@ -3818,10 +4157,24 @@
                 "undici-types": "~7.16.0"
             }
         },
+        "node_modules/@types/normalize-package-data": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+            "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/prettier": {
             "version": "2.7.3",
             "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
             "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/sarif": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
+            "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -4167,42 +4520,47 @@
             }
         },
         "node_modules/@vscode/vsce": {
-            "version": "2.32.0",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.32.0.tgz",
-            "integrity": "sha512-3EFJfsgrSftIqt3EtdRcAygy/OJ3hstyI1cDmIgkU9CFZW5C+3djr6mfosndCUqcVYuyjmxOK1xmFp/Bq7+NIg==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.2.tgz",
+            "integrity": "sha512-XSxMosEEDO6vLxELAHVkwmhC0qe0ijZni2jB9Rcs8kQsW4lhTDQ/wMzmwFs/buotAWSnpmUp/dRWD2ufG3UYKA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@azure/identity": "^4.1.0",
+                "@secretlint/node": "^10.1.2",
+                "@secretlint/secretlint-formatter-sarif": "^10.1.2",
+                "@secretlint/secretlint-rule-no-dotenv": "^10.1.2",
+                "@secretlint/secretlint-rule-preset-recommend": "^10.1.2",
                 "@vscode/vsce-sign": "^2.0.0",
                 "azure-devops-node-api": "^12.5.0",
-                "chalk": "^2.4.2",
+                "chalk": "^4.1.2",
                 "cheerio": "^1.0.0-rc.9",
                 "cockatiel": "^3.1.2",
-                "commander": "^6.2.1",
+                "commander": "^12.1.0",
                 "form-data": "^4.0.0",
-                "glob": "^7.0.6",
+                "glob": "^13.0.6",
                 "hosted-git-info": "^4.0.2",
                 "jsonc-parser": "^3.2.0",
                 "leven": "^3.1.0",
-                "markdown-it": "^12.3.2",
+                "markdown-it": "^14.1.0",
                 "mime": "^1.3.4",
-                "minimatch": "^3.0.3",
+                "minimatch": "^10.2.2",
                 "parse-semver": "^1.1.1",
                 "read": "^1.0.7",
+                "secretlint": "^10.1.2",
                 "semver": "^7.5.2",
-                "tmp": "^0.2.1",
+                "tmp": "^0.2.3",
                 "typed-rest-client": "^1.8.4",
                 "url-join": "^4.0.1",
                 "xml2js": "^0.5.0",
-                "yauzl": "^2.3.1",
+                "yauzl": "^3.2.1",
                 "yazl": "^2.2.2"
             },
             "bin": {
                 "vsce": "vsce"
             },
             "engines": {
-                "node": ">= 16"
+                "node": ">= 20"
             },
             "optionalDependencies": {
                 "keytar": "^7.7.0"
@@ -4352,6 +4710,152 @@
             "os": [
                 "win32"
             ]
+        },
+        "node_modules/@vscode/vsce/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/brace-expansion": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@vscode/vsce/node_modules/glob": {
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/minimatch": {
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.8"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/yauzl": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+            "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pend": "~1.2.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/@wasmer/wasi": {
             "version": "1.2.2",
@@ -4560,6 +5064,16 @@
             },
             "engines": {
                 "node": ">=12.0.0"
+            }
+        },
+        "node_modules/astral-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/async-function": {
@@ -4925,6 +5439,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/binaryextensions": {
+            "version": "6.11.0",
+            "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-6.11.0.tgz",
+            "integrity": "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==",
+            "dev": true,
+            "license": "Artistic-2.0",
+            "dependencies": {
+                "editions": "^6.21.0"
+            },
+            "engines": {
+                "node": ">=4"
+            },
+            "funding": {
+                "url": "https://bevry.me/fund"
+            }
+        },
         "node_modules/bip39": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
@@ -5040,6 +5570,13 @@
             "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
             "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
             "license": "MIT"
+        },
+        "node_modules/boundary": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
+            "integrity": "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==",
+            "dev": true,
+            "license": "BSD-2-Clause"
         },
         "node_modules/brace-expansion": {
             "version": "1.1.13",
@@ -5791,13 +6328,13 @@
             }
         },
         "node_modules/commander": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-            "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 6"
+                "node": ">=18"
             }
         },
         "node_modules/concat-map": {
@@ -6877,6 +7414,23 @@
                 "safe-buffer": "^5.0.1"
             }
         },
+        "node_modules/editions": {
+            "version": "6.22.0",
+            "resolved": "https://registry.npmjs.org/editions/-/editions-6.22.0.tgz",
+            "integrity": "sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==",
+            "dev": true,
+            "license": "Artistic-2.0",
+            "dependencies": {
+                "version-range": "^4.15.0"
+            },
+            "engines": {
+                "ecmascript": ">= es5",
+                "node": ">=4"
+            },
+            "funding": {
+                "url": "https://bevry.me/fund"
+            }
+        },
         "node_modules/electron-to-chromium": {
             "version": "1.5.267",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
@@ -7594,6 +8148,23 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+            "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/fastq": {
             "version": "1.20.1",
@@ -8986,6 +9557,19 @@
                 "node": ">=8"
             }
         },
+        "node_modules/index-to-position": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+            "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -9717,6 +10301,24 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/istextorbinary": {
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-9.5.0.tgz",
+            "integrity": "sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==",
+            "dev": true,
+            "license": "Artistic-2.0",
+            "dependencies": {
+                "binaryextensions": "^6.11.0",
+                "editions": "^6.21.0",
+                "textextensions": "^6.11.0"
+            },
+            "engines": {
+                "node": ">=4"
+            },
+            "funding": {
+                "url": "https://bevry.me/fund"
             }
         },
         "node_modules/jest": {
@@ -11431,10 +12033,20 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -11755,13 +12367,23 @@
             "license": "MIT"
         },
         "node_modules/linkify-it": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-            "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+            "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
-                "uc.micro": "^1.0.1"
+                "uc.micro": "^2.0.0"
             }
         },
         "node_modules/lint-staged": {
@@ -12188,6 +12810,13 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/lodash": {
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/lodash.includes": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -12242,6 +12871,13 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.truncate": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+            "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/log-update": {
@@ -12448,30 +13084,31 @@
             }
         },
         "node_modules/markdown-it": {
-            "version": "12.3.2",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-            "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+            "version": "14.3.1",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.1.tgz",
+            "integrity": "sha512-4Ej49aYTDFIQ+uBkfX8GBvJGccoARxxPep+7aWTs55ozbjQJpW9M26Fe53vnGgvLeVzva/amzjQQaQu9w0vMhA==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1",
-                "entities": "~2.1.0",
-                "linkify-it": "^3.0.1",
-                "mdurl": "^1.0.1",
-                "uc.micro": "^1.0.5"
+                "entities": "^4.5.0",
+                "linkify-it": "^5.0.2",
+                "mdurl": "^2.0.0",
+                "punycode.js": "^2.3.1",
+                "uc.micro": "^2.1.0"
             },
             "bin": {
-                "markdown-it": "bin/markdown-it.js"
-            }
-        },
-        "node_modules/markdown-it/node_modules/entities": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-            "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
+                "markdown-it": "bin/markdown-it.mjs"
             }
         },
         "node_modules/markdown-table": {
@@ -12572,9 +13209,9 @@
             "license": "CC0-1.0"
         },
         "node_modules/mdurl": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-            "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+            "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
             "dev": true,
             "license": "MIT"
         },
@@ -13333,6 +13970,20 @@
             "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/node-sarif-builder": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.4.0.tgz",
+            "integrity": "sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/sarif": "^2.1.7",
+                "fs-extra": "^11.1.1"
+            },
+            "engines": {
+                "node": ">=20"
+            }
         },
         "node_modules/normalize-package-data": {
             "version": "2.5.0",
@@ -14171,6 +14822,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/pluralize": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+            "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/possible-typed-array-names": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -14350,6 +15011,16 @@
                 "node": ">=6"
             }
         },
+        "node_modules/punycode.js": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/pure-rand": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -14450,6 +15121,19 @@
             },
             "bin": {
                 "rc": "cli.js"
+            }
+        },
+        "node_modules/rc-config-loader": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.4.tgz",
+            "integrity": "sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "js-yaml": "^4.1.1",
+                "json5": "^2.2.3",
+                "require-from-string": "^2.0.2"
             }
         },
         "node_modules/rc/node_modules/strip-json-comments": {
@@ -14914,6 +15598,101 @@
             },
             "engines": {
                 "node": ">=v12.22.7"
+            }
+        },
+        "node_modules/secretlint": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/secretlint/-/secretlint-10.2.2.tgz",
+            "integrity": "sha512-xVpkeHV/aoWe4vP4TansF622nBEImzCY73y/0042DuJ29iKIaqgoJ8fGxre3rVSHHbxar4FdJobmTnLp9AU0eg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@secretlint/config-creator": "^10.2.2",
+                "@secretlint/formatter": "^10.2.2",
+                "@secretlint/node": "^10.2.2",
+                "@secretlint/profiler": "^10.2.2",
+                "debug": "^4.4.1",
+                "globby": "^14.1.0",
+                "read-pkg": "^9.0.1"
+            },
+            "bin": {
+                "secretlint": "bin/secretlint.js"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/secretlint/node_modules/hosted-git-info": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+            "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^10.0.1"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/secretlint/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/secretlint/node_modules/normalize-package-data": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+            "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "hosted-git-info": "^7.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-license": "^3.0.4"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/secretlint/node_modules/parse-json": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+            "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.26.2",
+                "index-to-position": "^1.1.0",
+                "type-fest": "^4.39.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/secretlint/node_modules/read-pkg": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+            "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/normalize-package-data": "^2.4.3",
+                "normalize-package-data": "^6.0.0",
+                "parse-json": "^8.0.0",
+                "type-fest": "^4.6.0",
+                "unicorn-magic": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/seek-bzip": {
@@ -15621,6 +16400,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/structured-source": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
+            "integrity": "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boundary": "^2.0.0"
+            }
+        },
         "node_modules/supports-color": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -15632,6 +16421,46 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/supports-hyperlinks": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+            "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0",
+                "supports-color": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+            }
+        },
+        "node_modules/supports-hyperlinks/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/supports-hyperlinks/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/supports-preserve-symlinks-flag": {
@@ -15652,6 +16481,133 @@
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "license": "MIT"
+        },
+        "node_modules/table": {
+            "version": "6.9.0",
+            "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+            "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "ajv": "^8.0.1",
+                "lodash.truncate": "^4.4.2",
+                "slice-ansi": "^4.0.0",
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/table/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/table/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/table/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/table/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/table/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/table/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/table/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/table/node_modules/slice-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
+        "node_modules/table/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/tar": {
             "version": "7.5.11",
@@ -15768,6 +16724,39 @@
                 "node": ">=18"
             }
         },
+        "node_modules/terminal-link": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-4.0.0.tgz",
+            "integrity": "sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-escapes": "^7.0.0",
+                "supports-hyperlinks": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/terminal-link/node_modules/ansi-escapes": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+            "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "environment": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/terminal-size": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/terminal-size/-/terminal-size-4.0.0.tgz",
@@ -15802,6 +16791,29 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "b4a": "^1.6.4"
+            }
+        },
+        "node_modules/text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/textextensions": {
+            "version": "6.11.0",
+            "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-6.11.0.tgz",
+            "integrity": "sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==",
+            "dev": true,
+            "license": "Artistic-2.0",
+            "dependencies": {
+                "editions": "^6.21.0"
+            },
+            "engines": {
+                "node": ">=4"
+            },
+            "funding": {
+                "url": "https://bevry.me/fund"
             }
         },
         "node_modules/through": {
@@ -16218,9 +17230,9 @@
             }
         },
         "node_modules/uc.micro": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-            "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
             "dev": true,
             "license": "MIT"
         },
@@ -16513,6 +17525,19 @@
             "dependencies": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "node_modules/version-range": {
+            "version": "4.15.0",
+            "resolved": "https://registry.npmjs.org/version-range/-/version-range-4.15.0.tgz",
+            "integrity": "sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==",
+            "dev": true,
+            "license": "Artistic-2.0",
+            "engines": {
+                "node": ">=4"
+            },
+            "funding": {
+                "url": "https://bevry.me/fund"
             }
         },
         "node_modules/vscode-jsonrpc": {

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
         "@types/prettier": "^2.7.0",
         "@types/semver": "^7.7.1",
         "@types/vscode": "^1.53.0",
-        "@vscode/vsce": "^2.15.0",
+        "@vscode/vsce": "^3.9.2",
         "esbuild": "^0.28.1",
         "eslint": "^9.39.2",
         "eslint-plugin-jest": "^28.14.0",


### PR DESCRIPTION
## What

Fixes the CI failures on the v0.24.0 release publish step (run #34364094084).

### Actions bumped (all workflows: `release.yml`, `tests.yml`, `update-motoko.yml`)

| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | v3.6.0 / v4.3.1 / v5.0.1 | **v7.0.1** |
| `actions/setup-node` | v4.4.0 / v5.0.0 | **v7.0.0** |
| `actions/cache` | v4.3.0 / v5.0.5 | **v6.1.0** |
| `actions/create-github-app-token` | v1.12.0 | **v3.2.0** |
| `peter-evans/create-pull-request` | v7.0.11 | **v8.1.1** |

### `@vscode/vsce` bumped: v2 → v3

`@vscode/vsce` bumped from `^2.15.0` to `^3.9.2` (resolved: v3.9.2). v3 requires Node >= 20; CI already runs Node 24 so this is safe.

### Why

The v0.24.0 release run (#34364094084) failed with two issues:

1. **Node 20 deprecation** — `actions/checkout@v3.6.0` targets Node.js 20 and was forced to Node 24 by the runner, emitting a deprecation warning. All workflows now use native Node 24 actions.

2. **`Request timeout: /_apis/gallery`** — The v2 `vsce publish` timed out communicating with the VS Code Marketplace API. v3 brings updated `@azure/identity` and other networking improvements.

The PAT expiration (run #34470217161) is being handled separately.

### Verification

- `npm ci` ✅
- `npm run compile` ✅
- `npm test` — 24 suites, 276 tests all pass ✅
- `npm run --silent lint` — zero warnings ✅
- `npx vsce package` — successful packaging with vsce v3 ✅

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)