### PR TITLE
Release v0.24.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-motoko",
     "displayName": "Motoko",
     "description": "Motoko language support",
-    "version": "0.24.1",
+    "version": "0.24.2",
     "publisher": "dfinity-foundation",
     "repository": "https://github.com/caffeinelabs/vscode-motoko",
     "engines": {


### PR DESCRIPTION
## Release v0.24.2

Patch release: bump version from `0.24.1` to `0.24.2`.

### Release checklist
After merging:
1. Go to [GitHub Releases](https://github.com/caffeinelabs/vscode-motoko/releases) and draft a new release
2. Create a new tag `v0.24.2`
3. Leave the title blank (auto-populated)
4. Click **Generate release notes**, then **Publish release**

The release workflow will build the `.vsix`, publish to the VS Code Marketplace, and upload the asset.

Made with [Cursor](https://cursor.com)